### PR TITLE
Mango wrap execution in a promise

### DIFF
--- a/iat.js
+++ b/iat.js
@@ -95,7 +95,7 @@ window.IAT = (function(window, undefined) {
     testData = data;
     $targetEl = $root;
     updateStyles(urlBase);
-    loadTasks();
+    return loadTasks();
   }.bind(this);
 
   /**
@@ -227,17 +227,18 @@ window.IAT = (function(window, undefined) {
       if (taskIndex < countTask) {
         currentTaskIndex++;
         var data = testData[taskIndex];
-        start(data).then(function(answers) {
+        return start(data).then(function(answers) {
           answerStore.push(answers);
-          loadTask(currentTaskIndex);
+          return loadTask(currentTaskIndex);
         });
       } else {
         console.log('[IAT] Test is finished.');
         console.log(answerStore);
+        return answerStore;
       }
     };
 
-    loadTask(0);
+    return loadTask(0);
   }
 
   /**

--- a/iat.js
+++ b/iat.js
@@ -124,25 +124,6 @@ window.IAT = (function(window, undefined) {
   }
 
   /**
-   * Builds DOM tree for elements display by IAT.js (feedback, stimuli, etc...)
-   *
-   * @param  {Object}  $rootEl          jQuery-wrapped DOMElement serving as root node.
-   * @param  {...rest} restParamsNodes  Rest params of jQuery object or DOMElement to attach.
-   * @return {Object}  A jQuery-wrapped DOM tree.
-   */
-  function buildDOMTree($rootEl, restParamsNodes) {
-    var root = $rootEl;
-    var nodes = [].slice.call(arguments)
-                  .splice(1, arguments.length);
-
-    _.each(nodes, function(node) {
-      root.append(node);
-    });
-
-    return root;
-  }
-
-  /**
    * Displays an splash screen before starting a test block
    * @param  {left: <left-concept>: right: <right-concept>} data about the test block
    */
@@ -230,29 +211,6 @@ window.IAT = (function(window, undefined) {
         $redCross.css('display', 'none');
       });
     }
-  }
-
-  /**
-   * Promise to load JSON data.
-   *
-   * @param  {String} fileUri  Path to the file to load.
-   * @return {Object} Promise resolving loaded data.
-   */
-  function loadJSON(fileUri) {
-    var deferred = $.Deferred();
-
-    $.ajax({
-      dataType: 'json',
-      url: fileUri,
-    }).fail(function() {
-      console.log('[IAT] Failed loading data from ' + fileUri + '.');
-      deferred.reject();
-    }).done(function(data) {
-      console.log('[IAT] Loaded "' + fileUri + '".');
-      deferred.resolve(data);
-    });
-
-    return deferred.promise();
   }
 
   /**


### PR DESCRIPTION
test with this :

IAT.start($('body'), [
  {
    test: [
      {
        "type": "government",
        "items": [
          "senate",
          "house of representatives",
        ]
      },
      {
        "type": "private sector",
        "items": [
          "sales",
          "manufacturing",
        ]
      }
    ],
    splash: {
      message: 'sample text using the concepts {{left}} and {{right}}',
      buttonText: 'go ahead'
    }
  },
  {
    test: [
      {
        "type":"trustworthy",
        "items": [
          "ethical", "honest"
        ]
      },
      {
        "type": "untrustworthy",
        "items": [
          "corrupt", "dishonest"
        ]
      }
    ]
  }
]).then(function(result) {console.log('received results after promise: ', result);})
